### PR TITLE
Bug 1181153: use the new treestatus API [DO NOT LAND]

### DIFF
--- a/treestatus.py
+++ b/treestatus.py
@@ -46,8 +46,8 @@ class TreeStatus(object):
     def current_status(self, branch=''):
         if branch:
             branch = self.find_branch(branch)
-        r = requests.get('%s/%s?format=json' % (self._server, branch))
-        return r.json()
+        r = requests.get('%s/trees/%s' % (self._server, branch))
+        return r.json()['result']
 
 
 def setup(bot):


### PR DESCRIPTION
This changes pulsebot to use the new treestatus API being deployed in bug 1181153.  The major changes are to the URL (from https://treestatus.mozilla.org/{tree}?format=json to https://api.pub.build.mozilla.org/treestatus/{tree}) and to the response format (which now has a top-level object with a 'result' key).

I haven't tested this, and anyway the configuration needs to be changed (server = https://api.pub.build.mozilla.org/treestatus) before deploying.

Please don't deploy until the transition in bug 1181153 is complete.  The old site will remain functional for a little while (302'ing and proxying to the new), so you have some time to land this without interruption.
