### PR TITLE
Correctly detect merges

### DIFF
--- a/pulsebot/pulse_dispatch.py
+++ b/pulsebot/pulse_dispatch.py
@@ -128,7 +128,7 @@ class PulseDispatcher(object):
 
         # Kind of gross
         last_desc = changesets[-1]['desc'] if changesets else ''
-        merge = 'merge' in last_desc or 'Merge' in last_desc
+        merge = changesets[-1].get('is_merge') if changesets else False
 
         group_changesets = merge or len(changesets) > max_checkins
 
@@ -331,6 +331,7 @@ class TestPulseDispatcher(unittest.TestCase):
         'author': 'Sheriff',
         'revlink': 'https://server/repo/rev/890abcdef012',
         'desc': 'Merge branch into repo',
+        'is_merge': True,
     }]
 
     def test_create_messages(self):

--- a/pulsebot/pulse_hgpushes.py
+++ b/pulsebot/pulse_hgpushes.py
@@ -88,6 +88,8 @@ class PulseHgPushes(PulseListener):
                     'desc': desc[0].strip(),
                     'author': cs['author'].split(' <')[0].strip(),
                 }
+                if len(cs['parents']) > 1:
+                    data['is_merge'] = True
                 for l in desc:
                     if l.startswith('Source-Repo:'):
                         data['source-repo'] = l.split(' ', 1)[1]
@@ -231,7 +233,9 @@ class TestPushesInfo(unittest.TestCase):
                 'author': 'Gregory Szorc',
                 'revlink': 'https://hg.mozilla.org/integration/autoland/'
                            'rev/be030db91f00',
-                'desc': 'Bug 1322769 - Free the oxidized lizzard, vendor Servo'
+                'desc': 'Bug 1322769 - Free the oxidized lizzard, vendor '
+                        'Servo',
+                'is_merge': True,
             }],
             'pushlog': 'https://hg.mozilla.org/integration/autoland/'
                        'pushloghtml?startID=36889&endID=36890',


### PR DESCRIPTION
Make it so pulsebot no longer incorrectly reports servo sync pushes (or any other commit that has the string "[m|M]erge" in the message) as merges.  Fixes #11 