### PR TITLE
Leave bugs open on graphics

### DIFF
--- a/pulsebot.cfg.in
+++ b/pulsebot.cfg.in
@@ -34,4 +34,4 @@ server = https://api.pub.build.mozilla.org/treestatus/trees
 server = https://bugzilla.mozilla.org/
 api_key = @bugzilla.api_key@
 pulse = integration/b2g-inbound,integration/fx-team,integration/mozilla-inbound,integration/autoland,mozilla-central,hgcustom/version-control-tools,mozilla-build,webtools/reviewboard,projects/graphics,automation/conduit
-leave_open = integration/*,mozilla-central
+leave_open = integration/*,mozilla-central,projects/*


### PR DESCRIPTION
We want to treat graphics like the other integration branches and leave bugs open. We'll use bugherder to close them once they merge to m-c.