### PR TITLE
Report pushes to https://hg.mozilla.org/build/puppet/ to bugzilla

### DIFF
--- a/pulsebot.cfg.in
+++ b/pulsebot.cfg.in
@@ -33,5 +33,5 @@ server = https://api.pub.build.mozilla.org/treestatus/trees
 [bugzilla]
 server = https://bugzilla.mozilla.org/
 api_key = @bugzilla.api_key@
-pulse = integration/b2g-inbound,integration/fx-team,integration/mozilla-inbound,integration/autoland,mozilla-central,hgcustom/version-control-tools,mozilla-build,webtools/reviewboard,projects/graphics,automation/conduit,comm-central
+pulse = integration/b2g-inbound,integration/fx-team,integration/mozilla-inbound,integration/autoland,mozilla-central,hgcustom/version-control-tools,mozilla-build,webtools/reviewboard,projects/graphics,automation/conduit,comm-central,build/puppet
 leave_open = integration/*,mozilla-central,projects/*


### PR DESCRIPTION
@tomprince suggested to activate pulse on build puppet, in order to avoid writting comments like: https://bugzilla.mozilla.org/show_bug.cgi?id=1409091#c23. r? @glandium 