### PR TITLE
Strip quotes from authors

### DIFF
--- a/pulsebot/pulse_hgpushes.py
+++ b/pulsebot/pulse_hgpushes.py
@@ -86,7 +86,7 @@ class PulseHgPushes(PulseListener):
                 data = {
                     'revlink': revlink,
                     'desc': desc[0].strip(),
-                    'author': cs['author'].split(' <')[0].strip(),
+                    'author': cs['author'].split(' <')[0].strip(' "'),
                 }
                 if len(cs['parents']) > 1:
                     data['is_merge'] = True

--- a/pulsebot/pulse_hgpushes.py
+++ b/pulsebot/pulse_hgpushes.py
@@ -242,3 +242,23 @@ class TestPushesInfo(unittest.TestCase):
             'user': u'gszorc@mozilla.com'
         }]
         self.assertEquals(pushes, servo_results)
+
+        url = ('https://hg.mozilla.org/releases/mozilla-beta/json-pushes'
+               '?version=2&full=1&startID=9426&endID=9427')
+        pushes = list(PulseHgPushes.get_push_info_from(url))
+
+        self.maxDiff = None
+        quoted_user_results = [{
+            'changesets': [{
+                'author': 'Mozilla Releng Treescript',
+                'revlink': 'https://hg.mozilla.org/releases/mozilla-beta/rev/'
+                           'c12b6a853caa',
+                'desc': 'No bug - Tagging '
+                        '801112336847960bbb9a018695cf09ea437dc137 with '
+                        'FIREFOX_62_0b5_BUILD1 a=release CLOSED TREE',
+            }],
+            'pushlog': 'https://hg.mozilla.org/releases/mozilla-beta/'
+                       'pushloghtml?startID=9426&endID=9427',
+            'user': u'ffxbld'
+        }]
+        self.assertEquals(pushes, quoted_user_results)


### PR DESCRIPTION
I've been finding pulsebot comments like https://mozilla.logbot.info/developers/20180703#c14968795 mildly annoying, so hopefully this is an acceptable fix.