### PR TITLE
Update treestatus URL in config.

### DIFF
--- a/pulsebot.cfg.in
+++ b/pulsebot.cfg.in
@@ -28,7 +28,7 @@ gfx = projects/graphics
 conduit = automation/conduit
 
 [treestatus]
-server = https://api.pub.build.mozilla.org/treestatus/trees
+server = https://treestatus.mozilla-releng.net/trees
 
 [bugzilla]
 server = https://bugzilla.mozilla.org/


### PR DESCRIPTION
api.pub.build.mozilla.org has been turned off as part of the decommissioning
of SCL3, treestatus is now available at treestatus.mozilla-releng.net instead.

Without the correct URL pulsebot will fail to start with a connection timeout.