### PR TITLE
Update User-Agent header to identify as pulsebot

### DIFF
--- a/pulsebot/bugzilla.py
+++ b/pulsebot/bugzilla.py
@@ -14,6 +14,7 @@ class Bugzilla(object):
     def __init__(self, server, api_key):
         self._server = server.rstrip('/')
         self._session = requests.Session()
+        self._session.headers.update({'User-Agent': 'glandium/pulsebot'})
         self._session.params['api_key'] = api_key
 
     def get_fields(self, bug, fields):

--- a/pulsebot/bugzilla.py
+++ b/pulsebot/bugzilla.py
@@ -14,7 +14,7 @@ class Bugzilla(object):
     def __init__(self, server, api_key):
         self._server = server.rstrip('/')
         self._session = requests.Session()
-        self._session.headers.update({'User-Agent': 'glandium/pulsebot'})
+        self._session.headers.update({'User-Agent': 'pulsebot'})
         self._session.params['api_key'] = api_key
 
     def get_fields(self, bug, fields):


### PR DESCRIPTION
Identifying pulsebot via its user-agent permits Bugzilla's user-
based blocking/rate-limiting to whitelist pulsebot.