### PR TITLE
Support new Bugzilla 'checkin-needed-tb' keyword.

### DIFF
--- a/pulsebot/pulse_dispatch.py
+++ b/pulsebot/pulse_dispatch.py
@@ -271,9 +271,12 @@ class PulseDispatcher(object):
                     else:
                         message = '\n'.join(comment())
                         kwargs = {}
-                        if 'checkin-needed' in values.get('keywords', {}):
+                        remove_keywords = [kw for kw in ['checkin-needed',
+                                                         'checkin-needed-tb']
+                                           if kw in values.get('keywords', {})]
+                        if remove_keywords:
                             kwargs['keywords'] = {
-                                'remove': ['checkin-needed']
+                                'remove': remove_keywords
                             }
                         # TODO: reopen closed bugs on backout
                         if ('leave-open' not in values.get('keywords', {}) and


### PR DESCRIPTION
The Bugzilla keyword 'checkin-needed' is going away in Bug 1546667. Since Thunderbird still uses it, Emma was kind enough to create 'checkin-neeed-tb' for us to use.
Jörg mentioned that Pulsebot would need an update, I think this should work.