### PR TITLE
Bug 1825092 - Pulsebot should comment the changeset hash of the landed changesets to the bug for uplift landings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,5 @@ services:
       - BUGZILLA_SERVER=https://bugzilla.mozilla.org
       - BUGZILLA_API_KEY=APIKEY
       - BUGZILLA_PULSE=integration/b2g-inbound,integration/fx-team,integration/mozilla-inbound,integration/autoland,mozilla-central,hgcustom/version-control-tools,mozilla-build,webtools/reviewboard,projects/graphics,automation/conduit,comm-central,ci/ci-configuration,ci/ci-admin,ci/taskgraph
+      - BUGZILLA_UPLIFT=releases/mozilla-release,releases/mozilla-beta,releases/mozilla-esr
       - BUGZILLA_LEAVE_OPEN=integration/*,mozilla-central,projects/*,ci/*

--- a/pulsebot/bugzilla.py
+++ b/pulsebot/bugzilla.py
@@ -45,7 +45,7 @@ class Bugzilla(object):
             )
 
     def get_fields(self, bug, fields):
-        path = f"rest/bug/{bug}"
+        path = f"rest/pulsebot/bug/{bug}"
         bug_data = self._call(
             "GET", path, params={"include_fields": ",".join(fields)}
         )
@@ -53,16 +53,19 @@ class Bugzilla(object):
         return bug_data.get("bugs", [{}])[0]
 
     def get_comments(self, bug):
-        path = f"rest/bug/{bug}/comment"
+        path = f"rest/pulsebot/bug/{bug}/comment"
         bug_data = self._call(
-            "GET", path, params={"include_fields": "text"}
+            "GET", path, params={"include_fields": "text,tags"}
         )
         self._check_error("GET", path, bug_data)
         comments = bug_data["bugs"].get("%d" % bug, {}).get("comments", [])
-        return [c.get("text", "") for c in comments]
+        results = []
+        for c in comments:
+            results.append({"text": c.get("text", ""), "tags": c.get("tags", [])})
+        return results
 
-    def post_comment(self, bug, comment):
-        self._call("POST", f"rest/bug/{bug}/comment", json={"comment": comment})
+    def post_comment(self, bug, **kwargs):
+        self._call("POST", f"rest/pulsebot/bug/{bug}/comment", json=kwargs)
 
     def update_bug(self, bug, **kwargs):
-        self._call("PUT", f"rest/bug/{bug}", json=kwargs)
+        self._call("PUT", f"rest/pulsebot/bug/{bug}", json=kwargs)

--- a/pulsebot/config.py
+++ b/pulsebot/config.py
@@ -36,6 +36,7 @@ class Config(object):
 
         self.bugzilla_branches = DispatchConfig()
         self.bugzilla_leave_open = DispatchConfig()
+        self.uplift_branches = DispatchConfig()
 
         if not self.pulse_user:
             raise Exception("Missing configuration: pulse_user")
@@ -54,3 +55,7 @@ class Config(object):
             if os.getenv("BUGZILLA_LEAVE_OPEN"):
                 for branch in os.getenv("BUGZILLA_LEAVE_OPEN").split(","):
                     self.bugzilla_leave_open.add(branch)
+
+            if os.getenv("BUGZILLA_UPLIFT"):
+                for branch in os.getenv("BUGZILLA_UPLIFT").split(","):
+                    self.uplift_branches.add(branch)

--- a/pulsebot/pulse_dispatch.py
+++ b/pulsebot/pulse_dispatch.py
@@ -204,7 +204,7 @@ class PulseDispatcher(object):
                 # on mozilla-inbound when they were mentioned when landing
                 # on mozilla-central.
                 if not any(url[-12:] in comment.get("text", "") for comment in comments):
-                   cs_to_write.append(cs_info)
+                    cs_to_write.append(cs_info)
 
             if not cs_to_write:
                 continue
@@ -222,7 +222,7 @@ class PulseDispatcher(object):
                         else:
                             yield "Backout:"
                     elif info.pusher:
-                       yield "Pushed by %s:" % info.pusher
+                        yield "Pushed by %s:" % info.pusher
                     for cs in cs_to_write:
                         for line in self.bugzilla_summary(cs):
                             yield line
@@ -464,7 +464,7 @@ class TestPulseDispatcher(unittest.TestCase):
                 self.shutting_down = True
                 self.bugzilla_thread.join()
 
-        def do_push(push, leave_open = False):
+        def do_push(push, leave_open=False):
             dispatcher = TestPulseDispatcher()
             if leave_open:
                 push["pushlog"] = re.sub('repo', 'leave-open', push["pushlog"])
@@ -557,7 +557,7 @@ class TestPulseDispatcher(unittest.TestCase):
         )
 
         bz.clear()
-        do_push(push, leave_open = True)
+        do_push(push, leave_open=True)
         self.assertEqual(bz.data, {})
 
         bz.clear()
@@ -750,7 +750,7 @@ class TestPulseDispatcher(unittest.TestCase):
         test = TestPulseDispatcher(bugzilla_branches, push("repoc"))
         self.assertEqual(test.bugzilla, [])
 
-        bugzilla_branches= DispatchConfig()
+        bugzilla_branches = DispatchConfig()
         bugzilla_branches.add("repo*")
         bugzilla_branches = bugzilla_branches, {}, ["uplift-repo"]
         test = TestPulseDispatcher(bugzilla_branches, push("repo"))

--- a/pulsebot/pulse_dispatch.py
+++ b/pulsebot/pulse_dispatch.py
@@ -5,7 +5,6 @@
 import logging
 import os
 import re
-import sys
 import threading
 import time
 from urllib.parse import urlparse
@@ -25,7 +24,7 @@ from pulsebot.config import DispatchConfig
 logger = logging.getLogger(__name__)
 
 REVLINK_RE = re.compile("/rev/[^/]*$")
-
+APPROVE_RE = re.compile(" a=(.*)")
 
 # Stolen from pylib/mozautomation/mozautomation/commitparser.py from
 # https://hg.mozilla.org/hgcustom/version-control-tools
@@ -61,6 +60,7 @@ class BugInfo(object):
         self.pusher = pusher
         self.leave_open = False
         self.changesets = []
+        self.uplift = False
 
     def add_changeset(self, cs):
         self.changesets.append(
@@ -94,7 +94,7 @@ class PulseDispatcher(object):
         if config.pulse_max_checkins:
             self.max_checkins = config.pulse_max_checkins
 
-        if self.config.bugzilla_branches:
+        if self.config.bugzilla_branches or self.config.uplift_branches:
             self.bugzilla_queue = Queue(42)
             self.bugzilla_thread = threading.Thread(
                 target=self.bugzilla_reporter
@@ -109,59 +109,18 @@ class PulseDispatcher(object):
         url = urlparse(push["pushlog"])
         branch = os.path.dirname(url.path).strip("/")
         logger.info(f'report_one_push: {url.netloc}{url.path} {branch}')
-        if branch in self.config.bugzilla_branches:
+        if branch in self.config.bugzilla_branches or branch in self.config.uplift_branches:
             for info in self.munge_for_bugzilla(push):
                 if branch in self.config.bugzilla_leave_open:
                     info.leave_open = True
+
+                # Find out changeset is approved and branch is uplift
+                for cs in info.changesets:
+                    match = APPROVE_RE.search(cs["desc"])
+                    if match and branch in self.config.uplift_branches:
+                        info.uplift = True
+
                 self.bugzilla_queue.put(info)
-
-    @staticmethod
-    def create_messages(push, max_checkins=sys.maxsize, max_bugs=5):
-        max_bugs = max(1, max_bugs)
-        changesets = push["changesets"]
-        group = ""
-        group_bugs = []
-
-        # Kind of gross
-        last_desc = changesets[-1]["desc"] if changesets else ""
-        merge = changesets[-1].get("is_merge") if changesets else False
-
-        group_changesets = merge or len(changesets) > max_checkins
-
-        if not merge:
-            for cs in changesets:
-                revlink = cs["revlink"]
-                desc = cs["desc"]
-
-                if group_changesets:
-                    bugs = parse_bugs(desc)
-                    if bugs and bugs[0] not in group_bugs:
-                        logger.info(f'bug found: {bugs[0]}')
-                        group_bugs.append(bugs[0])
-                else:
-                    author = cs["author"]
-                    yield "%s - %s - %s" % (revlink, author, desc)
-
-        if group_changesets:
-            group = "%s - %d changesets" % (push["pushlog"], len(changesets))
-
-        if merge:
-            group += " - %s" % last_desc
-
-        if group:
-            if group_bugs and not merge:
-                group += " (bug%s %s%s)" % (
-                    "s" if len(group_bugs) > 1 else "",
-                    ", ".join(str(b) for b in group_bugs[:max_bugs]),
-                    " and %d other bug%s"
-                    % (
-                        len(group_bugs) - max_bugs,
-                        "s" if len(group_bugs) > max_bugs + 1 else "",
-                    )
-                    if len(group_bugs) > max_bugs
-                    else "",
-                )
-            yield group
 
     @staticmethod
     def munge_for_bugzilla(push):
@@ -231,51 +190,65 @@ class PulseDispatcher(object):
                 continue
 
             try:
-                comments = "\n".join(self.bugzilla.get_comments(info.bug))
+                comments = self.bugzilla.get_comments(info.bug)
+                comments_string = ""
+                for c in comments:
+                    comments_string += c.get("text", "") + "\n"
             except BugzillaError:
                 # Don't do anything on errors, such as "You are not authorized
                 # to access bug #xxxxx".
                 continue
 
             cs_to_write = []
-            for cs_info in info:
-                url = cs_info["revlink"]
+            for cs in info:
+                url = cs["revlink"]
                 # Only write about a changeset if it's never been mentioned
                 # at all. This makes us not emit changesets that e.g. land
                 # on mozilla-inbound when they were mentioned when landing
                 # on mozilla-central.
-                if url[-12:] not in comments:
-                    cs_to_write.append(cs_info)
+                if url[-12:] not in comments_string:
+                    cs_to_write.append(cs)
 
-            if cs_to_write:
-                is_backout = all(cs["is_backout"] for cs in cs_to_write)
+            if not cs_to_write:
+                continue
 
-                def comment():
+            is_backout = all(cs["is_backout"] for cs in cs_to_write)
+
+            def comment():
+                if info.uplift:
+                    for cs in cs_to_write:
+                        yield cs["revlink"]
+                else:
                     if is_backout:
                         if info.pusher:
                             yield "Backout by %s:" % info.pusher
                         else:
                             yield "Backout:"
                     elif info.pusher:
-                        yield "Pushed by %s:" % info.pusher
+                       yield "Pushed by %s:" % info.pusher
                     for cs in cs_to_write:
                         for line in self.bugzilla_summary(cs):
                             yield line
 
-                try:
-                    fields = ("whiteboard", "keywords", "status")
-                    values = self.bugzilla.get_fields(info.bug, fields)
-                    # Delay comments for backouts and checkin-needed in
-                    # whiteboard
-                    delay_comment = not delayed and (
-                        is_backout or "checkin-needed" in values.get("whiteboard", "")
+            try:
+                fields = ("whiteboard", "keywords", "status")
+                values = self.bugzilla.get_fields(info.bug, fields)
+                # Delay comments for backouts and checkin-needed in
+                # whiteboard
+                delay_comment = not delayed and (
+                    is_backout or "checkin-needed" in values.get("whiteboard", "")
+                )
+                if delay_comment:
+                    delayed_comments.append(
+                        (time.time() + self.backout_delay, info)
                     )
-                    if delay_comment:
-                        delayed_comments.append(
-                            (time.time() + self.backout_delay, info)
-                        )
+                else:
+                    message = "\n".join(comment())
+
+                    # Uplift comments just need comment + uplift tag
+                    if info.uplift:
+                        self.bugzilla.post_comment(info.bug, text=message, comment_tags=["uplift"])
                     else:
-                        message = "\n".join(comment())
                         kwargs = {}
                         remove_keywords = [
                             kw
@@ -298,14 +271,14 @@ class PulseDispatcher(object):
                             kwargs["comment"] = {"body": message}
                             self.bugzilla.update_bug(info.bug, **kwargs)
                         else:
-                            self.bugzilla.post_comment(info.bug, message)
-                except Exception:
-                    logger.exception(f"Failed to send comment to bug {info.bug}")
+                            self.bugzilla.post_comment(info.bug, text=message)
+            except Exception:
+                logger.exception(f"Failed to send comment to bug {info.bug}")
 
     def shutdown(self):
         self.hgpushes.shutdown()
         self.shutting_down = True
-        if self.config.bugzilla_branches:
+        if self.config.bugzilla_branches or self.config.uplift_branches:
             self.bugzilla_thread.join()
 
 
@@ -352,109 +325,24 @@ class TestPulseDispatcher(unittest.TestCase):
             "desc": "Merge branch into repo",
             "is_merge": True,
         },
+        {
+            "author": "Sheriff",
+            "revlink": "https://server/uplift-repo/rev/ec26c420eea4",
+            "desc": "Bug 46 - Excepteur sint occaecat cupidatat non proident a=someone",
+        },
     ]
 
-    def test_create_messages(self):
-        push = {
-            "pushlog": "https://server/repo/pushloghtml?startID=1&endID=2",
-            "changesets": self.CHANGESETS[:1],
-        }
-        result = [
-            "https://server/repo/rev/1234567890ab - Ann O'nymous - "
-            "Bug 42 - Changed something",
-        ]
-        self.assertEqual(list(PulseDispatcher.create_messages(push)), result)
-
-        push["changesets"].append(self.CHANGESETS[1])
-        result.append(
-            "https://server/repo/rev/234567890abc - Ann O'nymous - "
-            "Fixup for bug 42 - Changed something else",
-        )
-        self.assertEqual(list(PulseDispatcher.create_messages(push)), result)
-
-        push["changesets"].extend(self.CHANGESETS[2:5])
-        result.extend(
-            (
-                "https://server/repo/rev/34567890abcd - Anon Ymous - "
-                "Bug 43 - Lorem ipsum",
-                "https://server/repo/rev/4567890abcde - Anon Ymous - "
-                "Bug 43 - dolor sit amet",
-                "https://server/repo/rev/567890abcdef - Anon Ymous - "
-                "Bug 43 - consectetur adipiscing elit",
-            )
-        )
-        self.assertEqual(list(PulseDispatcher.create_messages(push)), result)
-
-        self.assertEqual(list(PulseDispatcher.create_messages(push, 5)), result)
-
-        push["changesets"].append(self.CHANGESETS[5])
-        self.assertEqual(
-            list(PulseDispatcher.create_messages(push, 5)),
-            [
-                "https://server/repo/pushloghtml?startID=1&endID=2 - 6 changesets "
-                "(bugs 42, 43, 44)"
-            ],
-        )
-        self.assertEqual(
-            list(PulseDispatcher.create_messages(push, 5, 1)),
-            [
-                "https://server/repo/pushloghtml?startID=1&endID=2 - 6 changesets "
-                "(bugs 42 and 2 other bugs)"
-            ],
-        )
-        self.assertEqual(
-            list(PulseDispatcher.create_messages(push, 5, 2)),
-            [
-                "https://server/repo/pushloghtml?startID=1&endID=2 - 6 changesets "
-                "(bugs 42, 43 and 1 other bug)"
-            ],
-        )
-
-        push["changesets"].append(self.CHANGESETS[6])
-        self.assertEqual(
-            list(PulseDispatcher.create_messages(push, 5)),
-            [
-                "https://server/repo/pushloghtml?startID=1&endID=2 - 7 changesets "
-                "(bugs 42, 43, 44, 45)"
-            ],
-        )
-        self.assertEqual(
-            list(PulseDispatcher.create_messages(push, 5, 1)),
-            [
-                "https://server/repo/pushloghtml?startID=1&endID=2 - 7 changesets "
-                "(bugs 42 and 3 other bugs)"
-            ],
-        )
-        self.assertEqual(
-            list(PulseDispatcher.create_messages(push, 5, 2)),
-            [
-                "https://server/repo/pushloghtml?startID=1&endID=2 - 7 changesets "
-                "(bugs 42, 43 and 2 other bugs)"
-            ],
-        )
-
-        push["changesets"].append(self.CHANGESETS[7])
-        self.assertEqual(
-            list(PulseDispatcher.create_messages(push, 5)),
-            [
-                "https://server/repo/pushloghtml?startID=1&endID=2 - 8 changesets "
-                "- Merge branch into repo"
-            ],
-        )
-        # Merges are always grouped
-        self.assertEqual(
-            list(PulseDispatcher.create_messages(push)),
-            [
-                "https://server/repo/pushloghtml?startID=1&endID=2 - 8 changesets "
-                "- Merge branch into repo"
-            ],
-        )
-
     def test_munge_for_bugzilla(self):
+        class TestPulseDispatcher(PulseDispatcher):
+            def __init__(self, push):
+                self.hgpushes = [push]
+                self.bugzilla = []
+
         def munge(push):
+            dispatcher = TestPulseDispatcher(push)
             return {
                 info.bug: list(info)
-                for info in PulseDispatcher.munge_for_bugzilla(push)
+                for info in dispatcher.munge_for_bugzilla(push)
             }
 
         push = {
@@ -520,6 +408,9 @@ class TestPulseDispatcher(unittest.TestCase):
         self.assertEqual(munge(push), result)
 
     def test_bugzilla_reporter(self):
+        class Dummy(object):
+            pass
+
         class TestBugzilla(object):
             def __init__(self):
                 self.comments = defaultdict(list)
@@ -537,15 +428,20 @@ class TestPulseDispatcher(unittest.TestCase):
                         result[field] = data
                 return result
 
-            def post_comment(self, bug, message):
-                self.comments[bug].append(message)
+            def post_comment(self, bug, **kwargs):
+                comment = {
+                    "text": kwargs.get("text", "")
+                }
+                if "comment_tags" in kwargs:
+                    comment["comment_tags"] = kwargs.get("comment_tags", [])
+                self.comments[bug].append(comment)
 
             def update_bug(self, bug, **kwargs):
                 # TODO: Handle keywords and whiteboard and add a test for the
                 # checkin-needed removal.
                 for k, v in kwargs.items():
                     if k == "comment":
-                        self.post_comment(bug, v["body"])
+                        self.post_comment(bug, text=v["body"])
                     else:
                         self.data[bug][k] = v
 
@@ -556,6 +452,10 @@ class TestPulseDispatcher(unittest.TestCase):
 
         class TestPulseDispatcher(PulseDispatcher):
             def __init__(self):
+                self.config = Dummy()
+                self.config.bugzilla_branches = ["repo"]
+                self.config.bugzilla_leave_open = ["leave-open"]
+                self.config.uplift_branches = ["uplift-repo"]
                 self.shutting_down = False
                 self.backout_delay = 0
                 self.bugzilla = bz
@@ -567,16 +467,13 @@ class TestPulseDispatcher(unittest.TestCase):
                 self.shutting_down = True
                 self.bugzilla_thread.join()
 
-        def do_push(push, leave_open=False):
+        def do_push(push, leave_open = False):
             dispatcher = TestPulseDispatcher()
-            try:
-                for info in dispatcher.munge_for_bugzilla(push):
-                    if leave_open:
-                        info.leave_open = leave_open
-                    dispatcher.bugzilla_queue.put(info)
-            finally:
-                dispatcher.bugzilla_queue.put(None)
-                dispatcher.shutdown()
+            if leave_open:
+                push["pushlog"] = re.sub('repo', 'leave-open', push["pushlog"])
+            dispatcher.report_one_push(push)
+            dispatcher.bugzilla_queue.put(None)
+            dispatcher.shutdown()
 
         push = {
             "pushlog": "https://server/repo/pushloghtml?startID=1&endID=2",
@@ -584,18 +481,18 @@ class TestPulseDispatcher(unittest.TestCase):
             "changesets": self.CHANGESETS[:1],
         }
         comments = {
-            42: [
-                "Pushed by foo@bar.com:\n"
+            42: [{
+                "text": "Pushed by foo@bar.com:\n"
                 "https://server/repo/rev/1234567890ab\n"
                 "Changed something"
-            ],
+            }],
         }
         do_push(push)
         self.assertEqual(bz.comments, comments)
 
         bz.clear()
         push["changesets"].append(self.CHANGESETS[1])
-        comments[42][0] += (
+        comments[42][0]["text"] += (
             "\n"
             "https://server/repo/rev/234567890abc\n"
             "Fixup for bug 42 - Changed something else"
@@ -605,17 +502,17 @@ class TestPulseDispatcher(unittest.TestCase):
 
         bz.clear()
         push["changesets"].extend(self.CHANGESETS[2:5])
-        comments[43] = [
-            "Pushed by foo@bar.com:\n"
+        comments[43] = [{
+            "text": "Pushed by foo@bar.com:\n"
             "https://server/repo/rev/34567890abcd\n"
             "Lorem ipsum\n"
             "https://server/repo/rev/4567890abcde\n"
             "dolor sit amet\n"
             "https://server/repo/rev/567890abcdef\n"
             "consectetur adipiscing elit"
-        ]
+        }]
         do_push(push)
-        self.assertEqual(bz.comments, comments)
+        self.assertDictEqual(bz.comments, comments)
 
         push["changesets"].append(
             {
@@ -624,28 +521,28 @@ class TestPulseDispatcher(unittest.TestCase):
                 "desc": "Backout bug 41 for bustage",
             }
         )
-        comments[41] = [
-            "Backout by foo@bar.com:\n"
+        comments[41] = [{
+            "text": "Backout by foo@bar.com:\n"
             "https://server/repo/rev/90abcdef0123\n"
-            "Backout for bustage",
-        ]
+            "Backout for bustage"
+        }]
         do_push(push)
         self.assertEqual(bz.comments, comments)
 
         bz.clear()
         # If there is already a comment for the landed changeset, don't
         # add one ourselves.
-        bz.post_comment(42, "Landed: https://server/repo/rev/1234567890ab")
+        bz.post_comment(42, text="Landed: https://server/repo/rev/1234567890ab")
         comments = {42: bz.get_comments(42)}
         push["changesets"] = self.CHANGESETS[:1]
         do_push(push)
         self.assertEqual(bz.comments, comments)
 
         push["changesets"].append(self.CHANGESETS[1])
-        comments[42].append(
-            "https://server/repo/rev/234567890abc\n"
+        comments[42].append({
+            "text": "https://server/repo/rev/234567890abc\n"
             "Fixup for bug 42 - Changed something else"
-        )
+        })
         do_push(push)
         self.assertEqual(bz.comments, comments)
 
@@ -663,7 +560,7 @@ class TestPulseDispatcher(unittest.TestCase):
         )
 
         bz.clear()
-        do_push(push, leave_open=True)
+        do_push(push, leave_open = True)
         self.assertEqual(bz.data, {})
 
         bz.clear()
@@ -675,6 +572,22 @@ class TestPulseDispatcher(unittest.TestCase):
         bz.fields[42] = {"status": "VERIFIED"}
         do_push(push)
         self.assertEqual(bz.data, {})
+
+        # Test for uplift specific comment
+        bz.clear()
+        push = {
+            "pushlog": "https://server/uplift-repo/pushloghtml?startID=1&endID=2",
+            "user": "foo@bar.com",
+            "changesets": self.CHANGESETS[-1:],
+        }
+        comments = {
+            46: [{
+                "text": "https://server/uplift-repo/rev/ec26c420eea4",
+                "comment_tags": ["uplift"]
+            }],
+        }
+        do_push(push)
+        self.assertEqual(bz.comments, comments)
 
     def test_bugzilla_summary(self):
         def summary_equals(desc, summary):
@@ -740,10 +653,11 @@ class TestPulseDispatcher(unittest.TestCase):
         class TestPulseDispatcher(PulseDispatcher):
             def __init__(self, bugzilla_branches, push):
                 self.max_checkins = 10
-                bugzilla_branches, bugzilla_leave_open = bugzilla_branches
+                bugzilla_branches, bugzilla_leave_open, uplift = bugzilla_branches
                 self.config = Dummy()
                 self.config.bugzilla_branches = bugzilla_branches
                 self.config.bugzilla_leave_open = bugzilla_leave_open
+                self.config.uplift_branches = uplift
                 self.hgpushes = [push]
                 self.bugzilla = []
                 self.change_reporter()
@@ -757,7 +671,9 @@ class TestPulseDispatcher(unittest.TestCase):
 
                 return FakeQueue()
 
-        def push(repo):
+        def push(repo, approver=""):
+            if approver:
+                approver = " a=%s" % approver
             return {
                 "pushlog": "https://server/%s/pushloghtml?startID=1&endID=2" % repo,
                 "user": "foo@bar.com",
@@ -765,12 +681,11 @@ class TestPulseDispatcher(unittest.TestCase):
                     {
                         "author": "Ann O'nymous",
                         "revlink": "https://server/%s/rev/1234567890ab" % repo,
-                        "desc": "Bug 42 - Changed something",
+                        "desc": "Bug 42 - Changed something%s" % approver,
                     }
                 ],
             }
-
-        bugzilla_branches = ["repoa", "repob"], {}
+        bugzilla_branches = ["repoa", "repob"], {}, ["uplift-repo"]
         test = TestPulseDispatcher(bugzilla_branches, push("repo"))
         self.assertEqual(test.bugzilla, [])
 
@@ -782,6 +697,7 @@ class TestPulseDispatcher(unittest.TestCase):
                     "bug": 42,
                     "pusher": "foo@bar.com",
                     "leave_open": False,
+                    "uplift": False,
                     "changesets": [
                         {
                             "desc": "Bug 42 - Changed something",
@@ -801,6 +717,7 @@ class TestPulseDispatcher(unittest.TestCase):
                     "bug": 42,
                     "pusher": "foo@bar.com",
                     "leave_open": False,
+                    "uplift": False,
                     "changesets": [
                         {
                             "desc": "Bug 42 - Changed something",
@@ -812,12 +729,33 @@ class TestPulseDispatcher(unittest.TestCase):
             ],
         )
 
+        # Test for uplift comment support
+        test = TestPulseDispatcher(bugzilla_branches, push("uplift-repo", approver="someone"))
+        self.assertEqual(
+            test.bugzilla,
+            [
+                {
+                    "bug": 42,
+                    "pusher": "foo@bar.com",
+                    "leave_open": False,
+                    "uplift": True,
+                    "changesets": [
+                        {
+                            "desc": "Bug 42 - Changed something a=someone",
+                            "is_backout": False,
+                            "revlink": "https://server/uplift-repo/rev/1234567890ab",
+                        }
+                    ]
+                }
+            ]
+        )
+
         test = TestPulseDispatcher(bugzilla_branches, push("repoc"))
         self.assertEqual(test.bugzilla, [])
 
-        bugzilla_branches = DispatchConfig()
+        bugzilla_branches= DispatchConfig()
         bugzilla_branches.add("repo*")
-        bugzilla_branches = bugzilla_branches, {}
+        bugzilla_branches = bugzilla_branches, {}, ["uplift-repo"]
         test = TestPulseDispatcher(bugzilla_branches, push("repo"))
         self.assertEqual(
             test.bugzilla,
@@ -826,6 +764,7 @@ class TestPulseDispatcher(unittest.TestCase):
                     "bug": 42,
                     "pusher": "foo@bar.com",
                     "leave_open": False,
+                    "uplift": False,
                     "changesets": [
                         {
                             "desc": "Bug 42 - Changed something",
@@ -845,6 +784,7 @@ class TestPulseDispatcher(unittest.TestCase):
                     "bug": 42,
                     "pusher": "foo@bar.com",
                     "leave_open": False,
+                    "uplift": False,
                     "changesets": [
                         {
                             "desc": "Bug 42 - Changed something",
@@ -861,7 +801,7 @@ class TestPulseDispatcher(unittest.TestCase):
 
         bugzilla_branches = DispatchConfig()
         bugzilla_branches.add("repo*")
-        bugzilla_branches = bugzilla_branches, {"repoa"}
+        bugzilla_branches = bugzilla_branches, {"repoa"}, ["uplift-repo"]
         test = TestPulseDispatcher(bugzilla_branches, push("repo"))
         self.assertEqual(
             test.bugzilla,
@@ -870,6 +810,7 @@ class TestPulseDispatcher(unittest.TestCase):
                     "bug": 42,
                     "pusher": "foo@bar.com",
                     "leave_open": False,
+                    "uplift": False,
                     "changesets": [
                         {
                             "desc": "Bug 42 - Changed something",
@@ -889,6 +830,7 @@ class TestPulseDispatcher(unittest.TestCase):
                     "bug": 42,
                     "pusher": "foo@bar.com",
                     "leave_open": True,
+                    "uplift": False,
                     "changesets": [
                         {
                             "desc": "Bug 42 - Changed something",
@@ -905,7 +847,7 @@ class TestPulseDispatcher(unittest.TestCase):
 
         bugzilla_branches = DispatchConfig()
         bugzilla_branches.add("repo*")
-        bugzilla_branches = bugzilla_branches, bugzilla_branches
+        bugzilla_branches = bugzilla_branches, bugzilla_branches, bugzilla_branches
         test = TestPulseDispatcher(bugzilla_branches, push("repo"))
         self.assertEqual(
             test.bugzilla,
@@ -914,6 +856,7 @@ class TestPulseDispatcher(unittest.TestCase):
                     "bug": 42,
                     "pusher": "foo@bar.com",
                     "leave_open": True,
+                    "uplift": False,
                     "changesets": [
                         {
                             "desc": "Bug 42 - Changed something",
@@ -933,6 +876,7 @@ class TestPulseDispatcher(unittest.TestCase):
                     "bug": 42,
                     "pusher": "foo@bar.com",
                     "leave_open": True,
+                    "uplift": False,
                     "changesets": [
                         {
                             "desc": "Bug 42 - Changed something",

--- a/pulsebot/pulse_dispatch.py
+++ b/pulsebot/pulse_dispatch.py
@@ -191,23 +191,20 @@ class PulseDispatcher(object):
 
             try:
                 comments = self.bugzilla.get_comments(info.bug)
-                comments_string = ""
-                for c in comments:
-                    comments_string += c.get("text", "") + "\n"
             except BugzillaError:
                 # Don't do anything on errors, such as "You are not authorized
                 # to access bug #xxxxx".
                 continue
 
             cs_to_write = []
-            for cs in info:
-                url = cs["revlink"]
+            for cs_info in info:
+                url = cs_info["revlink"]
                 # Only write about a changeset if it's never been mentioned
                 # at all. This makes us not emit changesets that e.g. land
                 # on mozilla-inbound when they were mentioned when landing
                 # on mozilla-central.
-                if url[-12:] not in comments_string:
-                    cs_to_write.append(cs)
+                if not any(url[-12:] in comment.get("text", "") for comment in comments):
+                   cs_to_write.append(cs_info)
 
             if not cs_to_write:
                 continue


### PR DESCRIPTION
* Added new config for BUGZILLA_UPLIFT which lists repos which are considered to be uplift repos and the comments should be different for pushlogs on those branches.
* Update bugzilla.py utility methods to use the new custom API endpoint for Lando/Pulsebot which allows updating comment tags when creating comments. As well as to be able to update private bugs.
* Update test cases to test for uplift comments
* Removed unused code, create_messages(), and related test code.