### PR TITLE
Bug 1825092 - Pulsebot should comment the changeset hash of the landed changesets to the bug for uplift landings (Fixes to match BMO API)

### DIFF
--- a/pulsebot/bugzilla.py
+++ b/pulsebot/bugzilla.py
@@ -34,7 +34,7 @@ class Bugzilla(object):
         r = getattr(requests, method)(bug_url, headers=self._headers, **kwargs)
         if r.status_code not in (200, 201):
             raise BugzillaError(
-                f"Request Error: {method.upper()} {bug_url} {r.status_code} {r.reason}"
+                f"Request Error: {method.upper()} {bug_url} {r.status_code} {r.reason} {r.text}"
             )
         return r.json()
 
@@ -65,7 +65,9 @@ class Bugzilla(object):
         return results
 
     def post_comment(self, bug, **kwargs):
+        kwargs["comment"] = kwargs["text"]
         self._call("POST", f"rest/pulsebot/bug/{bug}/comment", json=kwargs)
 
     def update_bug(self, bug, **kwargs):
-        self._call("PUT", f"rest/pulsebot/bug/{bug}", json=kwargs)
+        kwargs["ids"] = [bug]
+        self._call("PUT", "rest/pulsebot/bug", json=kwargs)


### PR DESCRIPTION
* Updated to match the PhabBugz REST API endpoint properly
* For `POST /rest/pulsebot/bug/[id]/comment`, the proper parameter should have been `comment` and not `text`.
* For `PUT /rest/pulsebut/bug` ,  the bug id is not part of the URL and instead needed to be passed in the JSON body as `ids`.
	* This is different than the standard `PUT /rest/bug/[id]` in that that one allows for the bug id to be part of the URL and part of the JSON body. 

It is less work to make Pulsebot match the PhabBugz API than to update BMO code to match what Pulsebot expects so I am fixing this in Pulsebot. To test, I hardcoded all of the bug ids to be a known test bug on bugzilla-dev and ran a local instance of pulsebot against bugzilla-dev. You can see the successful comments on https://bugzilla-dev.allizom.org/show_bug.cgi?id=1632617.  Even Uplift comments seem to be working :)