### PR TITLE
docker-compose: add `projects/nss` to `BUGZILLA_PULSE` env var (Bug 1989581)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - PULSE_MAX_CHECKINS=10
       - BUGZILLA_SERVER=https://bugzilla.mozilla.org
       - BUGZILLA_API_KEY=APIKEY
-      - BUGZILLA_PULSE=integration/autoland,mozilla-central,hgcustom/version-control-tools,mozilla-build,automation/conduit,comm-central,ci/ci-configuration,ci/ci-admin,ci/taskgraph
+      - BUGZILLA_PULSE=integration/autoland,mozilla-central,hgcustom/version-control-tools,mozilla-build,automation/conduit,comm-central,ci/ci-configuration,ci/ci-admin,ci/taskgraph,projects/nss
       - BUGZILLA_UPLIFT=releases/mozilla-release,releases/mozilla-beta,releases/mozilla-esr
       - BUGZILLA_LEAVE_OPEN=integration/*,mozilla-central,projects/*,ci/*
       - GITHUB=mozilla-firefox/firefox:integration/autoland|mozilla-central|releases/mozilla-release|releases/mozilla-beta|releases/mozilla-esr


### PR DESCRIPTION
Keep the env var in our `docker-compose.yml` the same as in prod.
